### PR TITLE
Fix: Data generation of damage type tags fails

### DIFF
--- a/src/main/java/com/lying/tricksy/data/TFDataGenerators.java
+++ b/src/main/java/com/lying/tricksy/data/TFDataGenerators.java
@@ -10,11 +10,16 @@ public class TFDataGenerators implements DataGeneratorEntrypoint
 		FabricDataGenerator.Pack pack = fabricDataGenerator.createPack();
 		pack.addProvider(TFBlockLootTables::new);
 		pack.addProvider(TFDamageTypesProvider::new);
-//		pack.addProvider(TFDamageTypeTagProvider::new);
+		pack.addProvider(TFDamageTypeTagProvider::new);
 		pack.addProvider(TFRecipeProvider::new);
 		pack.addProvider(TFEntityTags::new);
 		pack.addProvider(TFBlockTags::new);
 		pack.addProvider(TFItemTags::new);
 		pack.addProvider(TFPathsProvider::new);
+	}
+	
+	@Override
+	public void buildRegistry(RegistryBuilder registryBuilder) {
+		registryBuilder.addRegistry(RegistryKeys.DAMAGE_TYPE, TFDamageTypes::bootstrap);
 	}
 }

--- a/src/main/java/com/lying/tricksy/init/TFDamageTypes.java
+++ b/src/main/java/com/lying/tricksy/init/TFDamageTypes.java
@@ -29,9 +29,8 @@ public class TFDamageTypes
 		return type;
 	}
 	
-	public static void init()
-	{
-		// ???
+	public static void bootstrap(Registerable<DamageType> registerable){
+		registerable.register(FOXFIRE, TYPES.get(FOXFIRE));
 	}
 	
 	public static Collection<DamageType> sources() { return TYPES.values(); }


### PR DESCRIPTION
Seems that the damage types declared in TFDamageTypes need to be basically pre-registered in order for datagen to be able to make use of them. I can't quite explain _why_ this is the case but it's how vanilla and other mods do it. In any case, it solves the issue.